### PR TITLE
feat: add link to the Dart doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Dart client library to interact with Supabase Storage.
 
+- Documentation: https://supabase.io/docs/reference/dart/storage-createbucket
+
 [![pub package](https://img.shields.io/pub/v/storage_client.svg)](https://pub.dev/packages/storage_client)
 [![pub test](https://github.com/supabase/storage-dart/workflows/Test/badge.svg)](https://github.com/supabase/storage-dart/actions?query=workflow%3ATest)
 
@@ -16,6 +18,8 @@ Dart client library to interact with Supabase Storage.
 ## License
 
 This repo is licensed under MIT.
+
+https://github.com/dshukertjr/storage-dart.git
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ Dart client library to interact with Supabase Storage.
 
 This repo is licensed under MIT.
 
-https://github.com/dshukertjr/storage-dart.git
-
 ## Credits
 
 - https://github.com/supabase/storage-js - ported from supabase/storage-js


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds a link to the Dart doc for storage. 

Closes https://github.com/supabase/storage-dart/issues/1

## What is the current behavior?

There are no doc or link to any docs in the repo. 

## What is the new behavior?

Users can navigate themselves to the official doc. 
