### PR TITLE
Fix/types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [1.0.0-dev.2]
 
 - fix: don't export `FetchOptions`
+- feat: `StorageException` implements `Exception`
 
 ## [1.0.0-dev.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## [1.0.0-dev.2]
 
-- BREAKING: rename `StorageException` to `StorageError`
+- fix: don't export `FetchOptions`
 
 ## [1.0.0-dev.1]
 
@@ -21,7 +21,7 @@ Now:
 ```dart
 try {
   final data = await ....;
-} on StorageError catch (error) {
+} on StorageException catch (error) {
   // handle storage errors
 } catch (error) {
   // handle other errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.0.0-dev.2]
+
+- BREAKING: rename `StorageException` to `StorageError`
+
 ## [1.0.0-dev.1]
 
 - BREAKING: error is now thrown instead of returned within the responses.

--- a/lib/src/fetch.dart
+++ b/lib/src/fetch.dart
@@ -24,19 +24,19 @@ class Fetch {
     return MediaType.parse(mime ?? 'application/octet-stream');
   }
 
-  StorageException _handleError(dynamic error, StackTrace stack) {
+  StorageError _handleError(dynamic error, StackTrace stack) {
     if (error is http.Response) {
       try {
         final data = json.decode(error.body) as Map<String, dynamic>;
-        return StorageException.fromJson(data, '${error.statusCode}');
+        return StorageError.fromJson(data, '${error.statusCode}');
       } on FormatException catch (_) {
-        return StorageException(
+        return StorageError(
           error.body,
           statusCode: '${error.statusCode}',
         );
       }
     } else {
-      return StorageException(
+      return StorageError(
         error.toString(),
         statusCode: error.runtimeType.toString(),
       );

--- a/lib/src/fetch.dart
+++ b/lib/src/fetch.dart
@@ -24,19 +24,19 @@ class Fetch {
     return MediaType.parse(mime ?? 'application/octet-stream');
   }
 
-  StorageError _handleError(dynamic error, StackTrace stack) {
+  StorageException _handleError(dynamic error, StackTrace stack) {
     if (error is http.Response) {
       try {
         final data = json.decode(error.body) as Map<String, dynamic>;
-        return StorageError.fromJson(data, '${error.statusCode}');
+        return StorageException.fromJson(data, '${error.statusCode}');
       } on FormatException catch (_) {
-        return StorageError(
+        return StorageException(
           error.body,
           statusCode: '${error.statusCode}',
         );
       }
     } else {
-      return StorageError(
+      return StorageException(
         error.toString(),
         statusCode: error.runtimeType.toString(),
       );

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -181,17 +181,22 @@ class SignedUrl {
   }
 }
 
-class StorageException {
+class StorageException implements Exception {
   final String message;
   final String? error;
   final String? statusCode;
 
-  const StorageException(this.message, {this.error, this.statusCode});
+  const StorageException(this.message, {this.error, this.statusCode}) : super();
 
-  StorageException.fromJson(Map<String, dynamic> json, [String? statusCode])
-      : message = json['message'] as String? ?? json.toString(),
-        error = json['error'] as String?,
-        statusCode = (json['statusCode'] as String?) ?? statusCode;
+  factory StorageException.fromJson(
+    Map<String, dynamic> json, [
+    String? statusCode,
+  ]) =>
+      StorageException(
+        json['message'] as String? ?? json.toString(),
+        error: json['error'] as String?,
+        statusCode: (json['statusCode'] as String?) ?? statusCode,
+      );
 
   @override
   String toString() {

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -181,14 +181,14 @@ class SignedUrl {
   }
 }
 
-class StorageException {
+class StorageError {
   final String message;
   final String? error;
   final String? statusCode;
 
-  const StorageException(this.message, {this.error, this.statusCode});
+  const StorageError(this.message, {this.error, this.statusCode});
 
-  StorageException.fromJson(Map<String, dynamic> json, [String? statusCode])
+  StorageError.fromJson(Map<String, dynamic> json, [String? statusCode])
       : message = json['message'] as String? ?? json.toString(),
         error = json['error'] as String?,
         statusCode = (json['statusCode'] as String?) ?? statusCode;

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -181,14 +181,14 @@ class SignedUrl {
   }
 }
 
-class StorageError {
+class StorageException {
   final String message;
   final String? error;
   final String? statusCode;
 
-  const StorageError(this.message, {this.error, this.statusCode});
+  const StorageException(this.message, {this.error, this.statusCode});
 
-  StorageError.fromJson(Map<String, dynamic> json, [String? statusCode])
+  StorageException.fromJson(Map<String, dynamic> json, [String? statusCode])
       : message = json['message'] as String? ?? json.toString(),
         error = json['error'] as String?,
         statusCode = (json['statusCode'] as String?) ?? statusCode;

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -200,6 +200,6 @@ class StorageException implements Exception {
 
   @override
   String toString() {
-    return 'StorageError(message: $message, statusCode: $statusCode, error: $error)';
+    return 'StorageException(message: $message, statusCode: $statusCode, error: $error)';
   }
 }

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,1 +1,1 @@
-const version = '1.0.0-dev.1';
+const version = '1.0.0-dev.2';

--- a/lib/storage_client.dart
+++ b/lib/storage_client.dart
@@ -1,4 +1,4 @@
 library storage_client;
 
 export 'src/storage_client.dart';
-export 'src/types.dart';
+export 'src/types.dart' hide FetchOptions;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: storage_client
 description: Dart client library to interact with Supabase Storage.
-version: 1.0.0-dev.1
+version: 1.0.0-dev.2
 homepage: "https://supabase.io"
 repository: "https://github.com/supabase/storage-dart"
 

--- a/test/basic_test.dart
+++ b/test/basic_test.dart
@@ -3,6 +3,7 @@ import 'dart:typed_data';
 
 import 'package:mocktail/mocktail.dart';
 import 'package:storage_client/src/fetch.dart';
+import 'package:storage_client/src/types.dart';
 import 'package:storage_client/storage_client.dart';
 import 'package:test/test.dart';
 

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -1,4 +1,5 @@
 import 'package:mocktail/mocktail.dart';
+import 'package:storage_client/src/types.dart';
 import 'package:storage_client/storage_client.dart';
 import 'package:test/test.dart';
 


### PR DESCRIPTION
I'm hiding `FetchOptions`, because it causes a duplication with postgrest-dart when exported in supabase-dart. It's only used internally, nevertheless.
~~I'm renaming `StorageException` to `StorageError`, because the other classes like `GoTrueError` and `PostgrestError` are named like this as well.~~
Just to mention, the migration note in CHANGELOG.md is wrong, because it uses `StorageError`