### PR TITLE
feat: update ci schema and add some metadata.

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       PGRST_DB_ANON_ROLE: postgres
       PGRST_JWT_SECRET: super-secret-jwt-token-with-at-least-32-characters-long
   storage:
-    image: supabase/storage-api:v0.13.0
+    image: supabase/storage-api:latest
     ports:
       - '5000:5000'
     depends_on:

--- a/infra/postgres/storage-schema.sql
+++ b/infra/postgres/storage-schema.sql
@@ -74,37 +74,84 @@ BEGIN
 END
 $function$;
 
-CREATE OR REPLACE FUNCTION storage.search(prefix text, bucketname text, limits int DEFAULT 100, levels int DEFAULT 1, offsets int DEFAULT 0)
- RETURNS TABLE (
+create or replace function storage.search (
+  prefix text,
+  bucketname text,
+  limits int default 100,
+  levels int default 1,
+  offsets int default 0,
+  search text default '',
+  sortcolumn text default 'name',
+  sortorder text default 'asc'
+) returns table (
     name text,
     id uuid,
-    updated_at TIMESTAMPTZ,
-    created_at TIMESTAMPTZ,
-    last_accessed_at TIMESTAMPTZ,
+    updated_at timestamptz,
+    created_at timestamptz,
+    last_accessed_at timestamptz,
     metadata jsonb
   )
- LANGUAGE plpgsql
-AS $function$
-DECLARE
-_bucketId text;
-BEGIN
-    select buckets."id" from buckets where buckets.name=bucketname limit 1 into _bucketId;
-	return query 
-		with files_folders as (
-			select ((string_to_array(objects.name, '/'))[levels]) as folder
-			from objects
-			where objects.name ilike prefix || '%'
-			and bucket_id = _bucketId
-			GROUP by folder
-			limit limits
-			offset offsets
-		) 
-		select files_folders.folder as name, objects.id, objects.updated_at, objects.created_at, objects.last_accessed_at, objects.metadata from files_folders 
-		left join objects
-		on prefix || files_folders.folder = objects.name
-        where objects.id is null or objects.bucket_id=_bucketId;
-END
-$function$;
+as $$
+declare
+  v_order_by text;
+  v_sort_order text;
+begin
+  case
+    when sortcolumn = 'name' then
+      v_order_by = 'name';
+    when sortcolumn = 'updated_at' then
+      v_order_by = 'updated_at';
+    when sortcolumn = 'created_at' then
+      v_order_by = 'created_at';
+    when sortcolumn = 'last_accessed_at' then
+      v_order_by = 'last_accessed_at';
+    else
+      v_order_by = 'name';
+  end case;
+
+  case
+    when sortorder = 'asc' then
+      v_sort_order = 'asc';
+    when sortorder = 'desc' then
+      v_sort_order = 'desc';
+    else
+      v_sort_order = 'asc';
+  end case;
+
+  v_order_by = v_order_by || ' ' || v_sort_order;
+
+  return query execute
+    'with folders as (
+       select path_tokens[$1] as folder
+       from storage.objects
+         where objects.name ilike $2 || $3 || ''%''
+           and bucket_id = $4
+           and array_length(regexp_split_to_array(objects.name, ''/''), 1) <> $1
+       group by folder
+       order by folder ' || v_sort_order || '
+     )
+     (select folder as "name",
+            null as id,
+            null as updated_at,
+            null as created_at,
+            null as last_accessed_at,
+            null as metadata from folders)
+     union all
+     (select path_tokens[$1] as "name",
+            id,
+            updated_at,
+            created_at,
+            last_accessed_at,
+            metadata
+     from storage.objects
+     where objects.name ilike $2 || $3 || ''%''
+       and bucket_id = $4
+       and array_length(regexp_split_to_array(objects.name, ''/''), 1) = $1
+     order by ' || v_order_by || ')
+     limit $5
+     offset $6' using levels, prefix, search, bucketname, limits, offsets;
+end;
+$$ language plpgsql stable;
 
 GRANT ALL PRIVILEGES ON SCHEMA storage TO postgres;
 GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA storage TO postgres;

--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -42,18 +42,6 @@ class FileObject {
   final Metadata? metadata;
   final Bucket? buckets;
 
-  const FileObject({
-    required this.name,
-    required this.bucketId,
-    required this.owner,
-    required this.id,
-    required this.updatedAt,
-    required this.createdAt,
-    required this.lastAccessedAt,
-    required this.metadata,
-    required this.buckets,
-  });
-
   FileObject.fromJson(dynamic json)
       : id = (json as Map<String, dynamic>)['id'] as String?,
         name = json['name'] as String,
@@ -93,13 +81,13 @@ class FileOptions {
 }
 
 class SearchOptions {
-  /// The number of files you want to be returned. */
+  /// The number of files you want to be returned.
   final int? limit;
 
-  /// The starting position. */
+  /// The starting position.
   final int? offset;
 
-  /// The column to sort by. Can be any column inside a FileObject. */
+  /// The column to sort by. Can be any column inside a FileObject.
   final SortBy? sortBy;
 
   /// The search string to filter files by.
@@ -129,7 +117,9 @@ class SortBy {
   final String? column;
   final String? order;
 
-  const SortBy({this.column, this.order});
+  const SortBy({this.column, this.order})
+      : assert(order == 'asc' || order == 'desc',
+            '`order` has to be either \'asc\' or \'desc\'');
 
   Map<String, dynamic> toMap() {
     return {
@@ -139,14 +129,17 @@ class SortBy {
   }
 }
 
-// TODO: need to check for metadata props. The api swagger doesnt have.
 class Metadata {
-  const Metadata({required this.name});
-
   Metadata._fromJson(Map<String, dynamic> json)
-      : name = (json)['name'] as String;
+      : name = json['name'] as String?,
+        size = json['size'] as int?,
+        mimetype = json['mimetype'] as String?,
+        cacheControl = json['cacheControl'] as String?;
 
-  final String name;
+  final String? name;
+  final int? size;
+  final String? mimetype;
+  final String? cacheControl;
 }
 
 class SignedUrl {

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -24,59 +24,74 @@ void main() {
     registerFallbackValue(const FetchOptions());
   });
 
-  test('List buckets', () async {
-    final response = await client.listBuckets();
-    expect(response.length, 4);
+  group('files', () {
+    test('list with sort', () async {
+      final response = await client.from('bucket2').list(
+          path: 'authenticated',
+          searchOptions: SearchOptions(
+            limit: 1,
+            sortBy: SortBy(column: 'name', order: 'desc'),
+          ));
+      expect(response.length, 1);
+      expect(response.first.name, 'cat.jpg');
+    });
   });
 
-  test('Get bucket by id', () async {
-    final response = await client.getBucket('bucket2');
-    expect(response.name, 'bucket2');
-  });
+  group('buckets', () {
+    test('List buckets', () async {
+      final response = await client.listBuckets();
+      expect(response.length, 4);
+    });
 
-  test('Get bucket with wrong id', () async {
-    try {
-      await client.getBucket('not-exist-id');
-      fail('Bucket that does not exist was found');
-    } catch (error) {
-      expect(error, isNotNull);
-    }
-  });
+    test('Get bucket by id', () async {
+      final response = await client.getBucket('bucket2');
+      expect(response.name, 'bucket2');
+    });
 
-  test('Create new bucket', () async {
-    final response = await client.createBucket(newBucketName);
-    expect(response, newBucketName);
-  });
+    test('Get bucket with wrong id', () async {
+      try {
+        await client.getBucket('not-exist-id');
+        fail('Bucket that does not exist was found');
+      } catch (error) {
+        expect(error, isNotNull);
+      }
+    });
 
-  test('Create new public bucket', () async {
-    const newPublicBucketName = 'my-new-public-bucket';
-    await client.createBucket(
-      newPublicBucketName,
-      const BucketOptions(public: true),
-    );
-    final response = await client.getBucket(newPublicBucketName);
-    expect(response.public, true);
-    expect(response.name, newPublicBucketName);
-  });
+    test('Create new bucket', () async {
+      final response = await client.createBucket(newBucketName);
+      expect(response, newBucketName);
+    });
 
-  test('update bucket', () async {
-    final updateRes = await client.updateBucket(
-      newBucketName,
-      const BucketOptions(public: true),
-    );
-    expect(updateRes, 'Successfully updated');
+    test('Create new public bucket', () async {
+      const newPublicBucketName = 'my-new-public-bucket';
+      await client.createBucket(
+        newPublicBucketName,
+        const BucketOptions(public: true),
+      );
+      final response = await client.getBucket(newPublicBucketName);
+      expect(response.public, true);
+      expect(response.name, newPublicBucketName);
+    });
 
-    final getRes = await client.getBucket(newBucketName);
-    expect(getRes.public, true);
-  });
+    test('update bucket', () async {
+      final updateRes = await client.updateBucket(
+        newBucketName,
+        const BucketOptions(public: true),
+      );
+      expect(updateRes, 'Successfully updated');
 
-  test('Empty bucket', () async {
-    final response = await client.emptyBucket(newBucketName);
-    expect(response, 'Successfully emptied');
-  });
+      final getRes = await client.getBucket(newBucketName);
+      expect(getRes.public, true);
+    });
 
-  test('Delete bucket', () async {
-    final response = await client.deleteBucket(newBucketName);
-    expect(response, 'Successfully deleted');
+    test('Empty bucket', () async {
+      final response = await client.emptyBucket(newBucketName);
+      expect(response, 'Successfully emptied');
+    });
+
+    test('Delete bucket', () async {
+      final response = await client.deleteBucket(newBucketName);
+      expect(response, 'Successfully deleted');
+    });
   });
 }


### PR DESCRIPTION
Seems like the `search` rpc function in the storage-schema is a bit out dated, and the most recent one is [this](https://github.com/supabase/storage-api/blob/master/migrations/tenant/0009-search-files-search-function.sql#L3). Because of this, ci was not functioning correctly. This PR fixes that. 

Also adds some properties in `Metadata` object. 