### PR TITLE
Breaking: Update type of `metadata` to  Map<String, dynamic>

### DIFF
--- a/lib/src/types.dart
+++ b/lib/src/types.dart
@@ -39,7 +39,7 @@ class FileObject {
   final String? updatedAt;
   final String? createdAt;
   final String? lastAccessedAt;
-  final Metadata? metadata;
+  final Map<String, dynamic>? metadata;
   final Bucket? buckets;
 
   const FileObject({
@@ -62,9 +62,7 @@ class FileObject {
         updatedAt = json['updated_at'] as String?,
         createdAt = json['created_at'] as String?,
         lastAccessedAt = json['last_accessed_at'] as String?,
-        metadata = json['metadata'] != null
-            ? Metadata._fromJson(json['metadata'])
-            : null,
+        metadata = json['metadata'] as Map<String, dynamic>?,
         buckets =
             json['buckets'] != null ? Bucket.fromJson(json['buckets']) : null;
 }
@@ -137,16 +135,6 @@ class SortBy {
       'order': order,
     };
   }
-}
-
-// TODO: need to check for metadata props. The api swagger doesnt have.
-class Metadata {
-  const Metadata({required this.name});
-
-  Metadata._fromJson(Map<String, dynamic> json)
-      : name = (json)['name'] as String;
-
-  final String name;
 }
 
 class SignedUrl {

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -24,6 +24,11 @@ void main() {
     registerFallbackValue(const FetchOptions());
   });
 
+  test('List files', () async {
+    final response = await client.from('bucket2').list(path: 'public');
+    expect(response.length, 2);
+  });
+
   test('List buckets', () async {
     final response = await client.listBuckets();
     expect(response.length, 4);


### PR DESCRIPTION
Following the update in JS SDK https://github.com/supabase/storage-js/pull/90

Also I added a `List files` test, because there were no test methods using `FileObject`. 

Fixes https://github.com/supabase-community/supabase-flutter/issues/178