### PR TITLE
fix: set minimum SDK to 2.14.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,12 +9,12 @@ on:
 
 jobs:
   test:
-    name: Test / OS ${{ matrix.os }} / Node ${{ matrix.node }} / SDK ${{ matrix.sdk }}
+    name: Test / SDK ${{ matrix.sdk }}
     strategy:
       matrix:
         os: [ubuntu-latest]
         node: ['12']
-        sdk: [stable, beta, dev]
+        sdk: [2.14.0, stable, beta, dev]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ jobs:
   test:
     name: Test / SDK ${{ matrix.sdk }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest]
         node: ['12']

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: "https://supabase.io"
 repository: "https://github.com/supabase/storage-dart"
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.14.0 <3.0.0"
 
 dependencies:
   http: ^0.13.4
@@ -16,4 +16,4 @@ dependencies:
 dev_dependencies:
   mocktail: ^0.3.0
   test: ^1.21.4
-  lints: ^2.0.0
+  lints: ^1.0.1


### PR DESCRIPTION
- Runs github actions with Dart v2.14.0
- Lower package version to meet the requirement of  >=2.14.0